### PR TITLE
Update TwitchNotify.ini with new channel name

### DIFF
--- a/TwitchNotify.ini
+++ b/TwitchNotify.ini
@@ -8,7 +8,7 @@ autoupdate=0
 
 [users]
 ; list of users to notify about, each on separate line
-handmade_hero
+molly_rocket
 cmuratori
 j_blow
 gamesdonequick


### PR DESCRIPTION
The handmade_hero twitch channel has been renamed to molly_rocket. This list should be updated to reflect this change. It is likely that the steelgolem channel has also been changed into a different name, because there does not appear to be a channel by that name anymore.

~Aerek